### PR TITLE
fix: Proper Escrow Authority 

### DIFF
--- a/programs/solana-streaming-payments/src/lib.rs
+++ b/programs/solana-streaming-payments/src/lib.rs
@@ -4,7 +4,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
 
-declare_id!("294BsSNNf6Nt5T7xQZWSSQ5nAcPhcmkdtgkuUj2woCox");
+declare_id!("RMTdcrr5L5M32zBy86nQRghzfcBWVLQZ5AzFwiwsL62");
 
 #[program]
 pub mod solana_streaming_payments {
@@ -244,7 +244,6 @@ pub struct CreateStream<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(seed: u64)]
 pub struct RedeemStream<'info> {
     #[account(mut)]
     pub payee: Signer<'info>,
@@ -323,33 +322,6 @@ pub struct CancelStream<'info> {
     
     pub token_program: Program<'info, Token>,
 }
-
-
-// #[derive(Accounts)]
-// #[instruction(seed: u64)]
-// pub struct CheckStream<'info> {
-//     #[account(
-//         mut,
-//         has_one = payer,
-//         seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
-//         bump = stream.bump
-//     )]
-//     pub stream: Account<'info, Stream>,
-    
-//     #[account(mut)]
-//     pub payer: Signer<'info>,
-    
-//     /// CHECK: This is just a public key for the payee
-//     pub payee: AccountInfo<'info>,
-    
-//     #[account(
-//         mut,
-//         constraint = escrow_token.owner == payer.key()
-//     )]
-//     pub escrow_token: Account<'info, TokenAccount>,
-    
-//     pub token_program: Program<'info, Token>,
-// }
 
 #[account]
 #[derive(InitSpace)]

--- a/programs/solana-streaming-payments/src/lib.rs
+++ b/programs/solana-streaming-payments/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(unexpected_cfgs)]
 #![allow(deprecated)]
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Token, TokenAccount};
+use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
 
 declare_id!("294BsSNNf6Nt5T7xQZWSSQ5nAcPhcmkdtgkuUj2woCox");
 
@@ -17,97 +17,187 @@ pub mod solana_streaming_payments {
         duration_minutes: u64,
         fee_percentage: u8,
     ) -> Result<()> {
+        // Validate inputs
+        require!(amount > 0, ErrorCode::ZeroAmount);
+        require!(rate_per_minute > 0, ErrorCode::ZeroRate);
+        require!(duration_minutes > 0, ErrorCode::ZeroDuration);
+        require!(
+            amount >= rate_per_minute * duration_minutes,
+            ErrorCode::InsufficientFundsForStream
+        );
+
+        // Initialize the stream state account
         let stream = &mut ctx.accounts.stream;
-        let bump = ctx.bumps.stream;
         
         stream.payer = ctx.accounts.payer.key();
         stream.payee = ctx.accounts.payee.key();
+        stream.mint = ctx.accounts.mint.key();
         stream.amount = amount;
         stream.rate_per_minute = rate_per_minute;
         stream.start_time = Clock::get()?.unix_timestamp;
         stream.duration_minutes = duration_minutes;
         stream.fee_percentage = fee_percentage;
         stream.redeemed = 0;
-        stream.bump = bump;
+        stream.stream_bump = ctx.bumps.stream;
+        stream.escrow_bump = ctx.bumps.escrow_token;
 
         // Transfer funds to escrow
-        let cpi_accounts = token::Transfer {
-            from: ctx.accounts.payer_token.to_account_info(),
-            to: ctx.accounts.escrow_token.to_account_info(),
-            authority: ctx.accounts.payer.to_account_info(),
-        };
-        let cpi_program = ctx.accounts.token_program.to_account_info();
-        token::transfer(CpiContext::new(cpi_program, cpi_accounts), amount)?;
+        token::transfer(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                token::Transfer {
+                    from: ctx.accounts.payer_token.to_account_info(),
+                    to: ctx.accounts.escrow_token.to_account_info(),
+                    authority: ctx.accounts.payer.to_account_info(),
+                },
+            ),
+            amount,
+        )?;
         Ok(())
     }
 
-    pub fn redeem_stream(ctx: Context<RedeemStream>, _seed: u64) -> Result<()> {
+    pub fn redeem_stream(ctx: Context<RedeemStream>) -> Result<()> {
         // Immutable borrow for calculations
         let stream = &ctx.accounts.stream;
         let current_time = Clock::get()?.unix_timestamp;
         let elapsed_minutes = (current_time - stream.start_time) as u64 / 60;
+        let streamable_minutes = stream.duration_minutes.min(elapsed_minutes);
 
-        let redeemable_amount = elapsed_minutes * stream.rate_per_minute;
-        let amount_to_redeem = redeemable_amount.min(stream.amount - stream.redeemed);
+        let redeemable_amount = streamable_minutes * stream.rate_per_minute;
+        let amount_to_redeem = redeemable_amount.saturating_sub(stream.redeemed).min(stream.amount - stream.redeemed);
 
-        if amount_to_redeem == 0 {
-            return Err(ErrorCode::NoFundsToRedeem.into());
-        }
+        require!(amount_to_redeem > 0, ErrorCode::NoFundsToRedeem);
 
         let fee = (amount_to_redeem * stream.fee_percentage as u64) / 100;
         let amount_to_payee = amount_to_redeem - fee;
 
-        // Transfer to payee
-        let cpi_program = ctx.accounts.token_program.to_account_info();
-        let cpi_accounts = token::Transfer {
-            from: ctx.accounts.escrow_token.to_account_info(),
-            to: ctx.accounts.payee_token.to_account_info(),
-            authority: ctx.accounts.payer.to_account_info(),
-        };
-        token::transfer(
-            CpiContext::new(cpi_program.clone(), cpi_accounts), 
-            amount_to_payee
-        )?;
+        // Define the PDA seeds for signing
+        let payer_key = stream.payer.key();
+        let payee_key = stream.payee.key();
+        let seeds = &[
+            b"escrow",
+            payer_key.as_ref(),
+            payee_key.as_ref(),
+            &[stream.escrow_bump],
+        ];
+        let signer = &[&seeds[..]];
 
-        // Transfer fee (if any)
-        if fee > 0 {
-            let cpi_accounts = token::Transfer {
-                from: ctx.accounts.escrow_token.to_account_info(),
-                to: ctx.accounts.fee_account.to_account_info(),
-                authority: ctx.accounts.payer.to_account_info(),
-            };
+        // Transfer funds to the payee
+        if amount_to_payee > 0 {
             token::transfer(
-                CpiContext::new(cpi_program, cpi_accounts), 
-                fee
+                CpiContext::new_with_signer(
+                    ctx.accounts.token_program.to_account_info(),
+                    Transfer {
+                        from: ctx.accounts.escrow_token.to_account_info(),
+                        to: ctx.accounts.payee_token.to_account_info(),
+                        authority: ctx.accounts.escrow_token.to_account_info(),
+                    },
+                    signer,
+                ),
+                amount_to_payee,
             )?;
         }
 
-        // Mutable borrow only for updating the account
-        let stream = &mut ctx.accounts.stream;
-        stream.redeemed += amount_to_redeem;
+        // Transfer fees to the fee account
+        if fee > 0 {
+            token::transfer(
+                CpiContext::new_with_signer(
+                    ctx.accounts.token_program.to_account_info(),
+                    Transfer {
+                        from: ctx.accounts.escrow_token.to_account_info(),
+                        to: ctx.accounts.fee_account.to_account_info(),
+                        authority: ctx.accounts.escrow_token.to_account_info(),
+                    },
+                    signer,
+                ),
+                fee,
+            )?;
+        }
+
+        // Update the redeemed amount in the stream state
+        let stream_mut = &mut ctx.accounts.stream;
+        stream_mut.redeemed += amount_to_redeem;
         Ok(())
     }
 
-    pub fn reclaim_stream(ctx: Context<ReclaimStream>, _seed: u64) -> Result<()> {
+    pub fn cancel_stream(ctx: Context<CancelStream>) -> Result<()> {
         let stream = &ctx.accounts.stream;
+
+        // First, redeem any outstanding balance to the payee
         let current_time = Clock::get()?.unix_timestamp;
         let elapsed_minutes = (current_time - stream.start_time) as u64 / 60;
+        let total_streamable_minutes = stream.duration_minutes.min(elapsed_minutes);
+        let redeemable_amount = total_streamable_minutes * stream.rate_per_minute;
+        let amount_to_payee = redeemable_amount.saturating_sub(stream.redeemed);
 
-        if elapsed_minutes < stream.duration_minutes {
-            return Err(ErrorCode::StreamNotExpired.into());
+        // Define the PDA seeds for signing
+        let payer_key = stream.payer.key();
+        let payee_key = stream.payee.key();
+        let seeds = &[
+            b"escrow",
+            payer_key.as_ref(),
+            payee_key.as_ref(),
+            &[stream.escrow_bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        if amount_to_payee > 0 {
+            let fee = (amount_to_payee * stream.fee_percentage as u64) / 100;
+            let net_to_payee = amount_to_payee - fee;
+
+            // Pay net amount to payee
+            if net_to_payee > 0 {
+                token::transfer(
+                    CpiContext::new_with_signer(
+                        ctx.accounts.token_program.to_account_info(),
+                        Transfer {
+                            from: ctx.accounts.escrow_token.to_account_info(),
+                            to: ctx.accounts.payee_token.to_account_info(),
+                            authority: ctx.accounts.escrow_token.to_account_info(),
+                        },
+                        signer,
+                    ),
+                    net_to_payee,
+                )?;
+            }
+            // Pay fee to fee_account
+            if fee > 0 {
+                token::transfer(
+                    CpiContext::new_with_signer(
+                        ctx.accounts.token_program.to_account_info(),
+                        Transfer {
+                            from: ctx.accounts.escrow_token.to_account_info(),
+                            to: ctx.accounts.fee_account.to_account_info(),
+                            authority: ctx.accounts.escrow_token.to_account_info(),
+                        },
+                        signer,
+                    ),
+                    fee,
+                )?;
+            }
         }
 
-        let remaining_amount = stream.amount - stream.redeemed;
 
-        if remaining_amount == 0 {
-            return Err(ErrorCode::NoFundsToReclaim.into());
+        // Refund the remaining balance to the payer
+        let remaining_amount = ctx.accounts.escrow_token.amount - amount_to_payee;
+        if remaining_amount > 0 {
+            token::transfer(
+                CpiContext::new_with_signer(
+                    ctx.accounts.token_program.to_account_info(),
+                    Transfer {
+                        from: ctx.accounts.escrow_token.to_account_info(),
+                        to: ctx.accounts.payer_token.to_account_info(),
+                        authority: ctx.accounts.escrow_token.to_account_info(),
+                    },
+                    signer,
+                ),
+                remaining_amount,
+            )?;
         }
-
-        // No need to transfer - the payer already owns the escrow account
-        // Just update the stream account to mark it as fully redeemed
-        let stream = &mut ctx.accounts.stream;
-        stream.redeemed = stream.amount;
         
+        // The `close` directive on the stream and escrow accounts will automatically
+        // trigger closing them and refunding the rent to the payer.
+
         Ok(())
     }
 }
@@ -118,7 +208,7 @@ pub struct CreateStream<'info> {
     #[account(
         init,
         payer = payer,
-        space = 8 + 32 + 32 + 8 + 8 + 8 + 8 + 1 + 8 + 1, // Space for Stream account
+        space = 8 + Stream::INIT_SPACE, // Space for Stream account
         seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
         bump
     )]
@@ -127,104 +217,168 @@ pub struct CreateStream<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
     
-    /// CHECK: This is just a public key for the payee
+    /// CHECK: The payee is the recipient of the stream, no checks needed here.
     pub payee: AccountInfo<'info>,
+
+    pub mint: Account<'info, Mint>,
     
     #[account(
         mut,
-        constraint = payer_token.owner == payer.key()
+        token::mint = mint,
+        token::authority = payer
     )]
     pub payer_token: Account<'info, TokenAccount>,
     
     #[account(
-        mut,
-        constraint = escrow_token.owner == payer.key()
+        init,
+        payer = payer,
+        token::mint = mint,
+        token::authority = escrow_token,
+        seeds = [b"escrow", payer.key().as_ref(), payee.key().as_ref()],
+        bump
     )]
     pub escrow_token: Account<'info, TokenAccount>,
     
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,
-    pub rent: Sysvar<'info, Rent>,
 }
 
 #[derive(Accounts)]
 #[instruction(seed: u64)]
 pub struct RedeemStream<'info> {
+    #[account(mut)]
+    pub payee: Signer<'info>,
+
     #[account(
         mut,
         has_one = payee,
+        has_one = payer,
         seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
-        bump = stream.bump
+        bump = stream.stream_bump
     )]
     pub stream: Account<'info, Stream>,
     
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    
-    #[account(mut)]
-    pub payee: Signer<'info>,
+    /// CHECK: Payer account from the stream state is used for seed derivation.
+    pub payer: AccountInfo<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"escrow", stream.payer.as_ref(), stream.payee.as_ref()],
+        bump = stream.escrow_bump
+    )]
+    pub escrow_token: Account<'info, TokenAccount>,
     
     #[account(
         mut,
-        constraint = payee_token.owner == payee.key()
+        token::mint = stream.mint
     )]
     pub payee_token: Account<'info, TokenAccount>,
     
     #[account(
         mut,
-        constraint = escrow_token.owner == payer.key()
+        token::mint = stream.mint
     )]
-    pub escrow_token: Account<'info, TokenAccount>,
-    
-    #[account(mut)]
     pub fee_account: Account<'info, TokenAccount>,
     
     pub token_program: Program<'info, Token>,
 }
 
 #[derive(Accounts)]
-#[instruction(seed: u64)]
-pub struct ReclaimStream<'info> {
-    #[account(
-        mut,
-        has_one = payer,
-        seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
-        bump = stream.bump
-    )]
-    pub stream: Account<'info, Stream>,
-    
+pub struct CancelStream<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
     
-    /// CHECK: This is just a public key for the payee
+    /// CHECK: The payee is checked via the has_one constraint on the stream account.
     pub payee: AccountInfo<'info>,
     
     #[account(
         mut,
-        constraint = escrow_token.owner == payer.key()
+        has_one = payer,
+        has_one = payee,
+        seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
+        bump = stream.stream_bump,
+        close = payer
+    )]
+    pub stream: Account<'info, Stream>,
+
+    #[account(
+        mut,
+        seeds = [b"escrow", stream.payer.as_ref(), stream.payee.as_ref()],
+        bump = stream.escrow_bump,
+        close = payer
     )]
     pub escrow_token: Account<'info, TokenAccount>,
+
+    #[account(mut, token::mint = stream.mint, token::authority = payer)]
+    pub payer_token: Account<'info, TokenAccount>,
+
+    #[account(mut, token::mint = stream.mint)]
+    pub payee_token: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        token::mint = stream.mint
+    )]
+    pub fee_account: Account<'info, TokenAccount>,
     
     pub token_program: Program<'info, Token>,
 }
 
+
+// #[derive(Accounts)]
+// #[instruction(seed: u64)]
+// pub struct CheckStream<'info> {
+//     #[account(
+//         mut,
+//         has_one = payer,
+//         seeds = [b"stream", payer.key().as_ref(), payee.key().as_ref()],
+//         bump = stream.bump
+//     )]
+//     pub stream: Account<'info, Stream>,
+    
+//     #[account(mut)]
+//     pub payer: Signer<'info>,
+    
+//     /// CHECK: This is just a public key for the payee
+//     pub payee: AccountInfo<'info>,
+    
+//     #[account(
+//         mut,
+//         constraint = escrow_token.owner == payer.key()
+//     )]
+//     pub escrow_token: Account<'info, TokenAccount>,
+    
+//     pub token_program: Program<'info, Token>,
+// }
+
 #[account]
+#[derive(InitSpace)]
 pub struct Stream {
     pub payer: Pubkey,
     pub payee: Pubkey,
+    pub mint: Pubkey,
     pub amount: u64,
     pub rate_per_minute: u64,
     pub start_time: i64,
     pub duration_minutes: u64,
     pub fee_percentage: u8,
     pub redeemed: u64,
-    pub bump: u8,
+    pub stream_bump: u8,
+    pub escrow_bump: u8,
 }
 
 #[error_code]
 pub enum ErrorCode {
     #[msg("No funds available to redeem.")]
     NoFundsToRedeem,
+    #[msg("Amount must be greater than zero.")]
+    ZeroAmount,
+    #[msg("Rate must be greater than zero.")]
+    ZeroRate,
+    #[msg("Duration must be greater than zero.")]
+    ZeroDuration,
+    #[msg("The amount provided is not sufficient to fund the stream for the given duration and rate.")]
+    InsufficientFundsForStream,
     #[msg("Stream has not expired yet.")]
     StreamNotExpired,
     #[msg("No funds available to reclaim.")]

--- a/tests/solana-streaming-payments.ts
+++ b/tests/solana-streaming-payments.ts
@@ -10,8 +10,7 @@ import {
   mintTo, 
   getAccount, 
   createAssociatedTokenAccount,
-  getOrCreateAssociatedTokenAccount,
-  createInitializeAccountInstruction
+  getOrCreateAssociatedTokenAccount
 } from "@solana/spl-token";
 import { assert } from "chai";
 
@@ -20,81 +19,71 @@ describe("solana-streaming-payments", () => {
   anchor.setProvider(provider);
   const program = anchor.workspace.SolanaStreamingPayments as Program<SolanaStreamingPayments>;
   
+  // Keypairs and addresses
   let mint: PublicKey;
-  let payer: PublicKey;
-  let payee: Keypair;
+  const payer = provider.wallet.publicKey;
+  const payee = anchor.web3.Keypair.generate();  // Generate a new wallet for the payee
+  const feeWallet = anchor.web3.Keypair.generate();  // Separate fee wallet for fee collection
+
+  // Token accounts
   let payerToken: PublicKey;
   let payeeToken: PublicKey;
-  let escrowToken: PublicKey;
   let feeAccount: PublicKey;
+
+  // PDAs
   let streamPda: PublicKey;
-  let streamBump: number;
-  
+  let escrowPda: PublicKey;
+
   before(async () => {
-    // Setup accounts and tokens
-    payer = provider.wallet.publicKey;
-    payee = anchor.web3.Keypair.generate();
-    
-    // Airdrop SOL to payee for rent
-    const signature = await provider.connection.requestAirdrop(
-      payee.publicKey,
-      1 * LAMPORTS_PER_SOL
+    // --- Setup Wallets ---
+    // Airdrop SOL to the payee and fee wallet so they can pay for account creation
+    const sig1 = await provider.connection.requestAirdrop(payee.publicKey, 1 * LAMPORTS_PER_SOL);
+    await provider.connection.confirmTransaction(
+      { signature: sig1, ...(await provider.connection.getLatestBlockhash()) },
+      "confirmed"
     );
-    await provider.connection.confirmTransaction(signature);
+
+    const sig2 = await provider.connection.requestAirdrop(feeWallet.publicKey, 1 * LAMPORTS_PER_SOL);
+    await provider.connection.confirmTransaction(
+      { signature: sig2, ...(await provider.connection.getLatestBlockhash()) },
+      "confirmed"
+    );
     
-    // Create mint
+    // --- Setup Tokens ---
+    // Create a new token mint
     mint = await createMint(
       provider.connection,
-      provider.wallet.payer,
-      payer,
-      null,
-      9
+      provider.wallet.payer, // Payer of fees
+      payer, // Mint authority
+      null, // Freeze authority
+      9 // Decimals
     );
     
-    // Create token accounts
-    payerToken = await createAssociatedTokenAccount(
-      provider.connection,
-      provider.wallet.payer,
-      mint,
-      payer
-    );
-    
-    payeeToken = await createAssociatedTokenAccount(
-      provider.connection,
-      provider.wallet.payer,
-      mint,
-      payee.publicKey
-    );
-    
-    // Create a second token account for the payer to use as escrow
-    // We'll create a regular token account with a new keypair
-    const escrowKeypair = Keypair.generate();
-    
-    // Create the token account
-    const tx = new anchor.web3.Transaction().add(
-      // Create account
-      SystemProgram.createAccount({
-        fromPubkey: payer,
-        newAccountPubkey: escrowKeypair.publicKey,
-        space: 165, // Size of token account
-        lamports: await provider.connection.getMinimumBalanceForRentExemption(165),
-        programId: TOKEN_PROGRAM_ID,
-      }),
-      // Initialize token account
-      createInitializeAccountInstruction(
-        escrowKeypair.publicKey,
+    // Create associated token accounts for each wallet
+    payerToken = (
+      await getOrCreateAssociatedTokenAccount(
+        provider.connection,
+        provider.wallet.payer,
         mint,
         payer
       )
+    ).address;
+
+    payeeToken = await createAssociatedTokenAccount(
+      provider.connection,
+      provider.wallet.payer, // Payer of fees
+      mint,
+      payee.publicKey
     );
-    
-    await provider.sendAndConfirm(tx, [escrowKeypair]);
-    escrowToken = escrowKeypair.publicKey;
-    
-    // Create fee account (reuse payer token account for simplicity)
-    feeAccount = payerToken;
-    
-    // Mint tokens to payer
+
+    feeAccount = await createAssociatedTokenAccount(
+      provider.connection,
+      provider.wallet.payer, // Payer of fees
+      mint,
+      feeWallet.publicKey
+    );
+
+    // Mint some tokens to the payer's account so they can fund the stream
     await mintTo(
       provider.connection,
       provider.wallet.payer,
@@ -103,170 +92,111 @@ describe("solana-streaming-payments", () => {
       payer,
       100 * LAMPORTS_PER_SOL
     );
-    
-    // Find PDA for stream
-    const [pda, bump] = PublicKey.findProgramAddressSync(
+
+    // --- Derive PDA Addresses ---
+    // Derive the PDA for the stream state account
+    [streamPda] = PublicKey.findProgramAddressSync(
       [Buffer.from("stream"), payer.toBuffer(), payee.publicKey.toBuffer()],
       program.programId
     );
-    streamPda = pda;
-    streamBump = bump;
+
+    // Derive the PDA for the program-controlled escrow token account
+    [escrowPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("escrow"), payer.toBuffer(), payee.publicKey.toBuffer()],
+      program.programId
+    );
   });
 
   it("Creates a stream", async () => {
+    const streamAmount = new anchor.BN(10 * LAMPORTS_PER_SOL);
+    const ratePerMinute = new anchor.BN(1 * LAMPORTS_PER_SOL); // 1 token per minute
+    const durationMinutes = new anchor.BN(10);
+    const feePercentage = 5; // 5%
+
     await program.methods
-      .createStream(
-        new anchor.BN(10 * LAMPORTS_PER_SOL), 
-        new anchor.BN(5 * LAMPORTS_PER_SOL), // 5 tokens per minute
-        new anchor.BN(60), 
-        5
-      )
+      .createStream(streamAmount, ratePerMinute, durationMinutes, feePercentage)
       .accounts({
         stream: streamPda,
+        escrowToken: escrowPda,
         payer: payer,
         payee: payee.publicKey,
+        mint: mint,
         payerToken: payerToken,
-        escrowToken: escrowToken,
         tokenProgram: TOKEN_PROGRAM_ID,
         systemProgram: SystemProgram.programId,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
       })
       .rpc();
 
+    // --- Verification ---
     const streamAccount = await program.account.stream.fetch(streamPda);
     assert.equal(streamAccount.payer.toString(), payer.toString());
     assert.equal(streamAccount.payee.toString(), payee.publicKey.toString());
-    assert.equal(streamAccount.amount.toString(), (10 * LAMPORTS_PER_SOL).toString());
-    assert.equal(streamAccount.ratePerMinute.toString(), (5 * LAMPORTS_PER_SOL).toString());
-    assert.equal(streamAccount.feePercentage, 5);
-    assert.equal(streamAccount.bump, streamBump);
-    
-    // Check escrow token balance
-    const escrowTokenAccount = await getAccount(provider.connection, escrowToken);
-    assert.equal(escrowTokenAccount.amount.toString(), (10 * LAMPORTS_PER_SOL).toString());
+    assert.equal(streamAccount.amount.toString(), streamAmount.toString());
+    assert.equal(
+      streamAccount.ratePerMinute.toString(),
+      ratePerMinute.toString()
+    );
+    assert.equal(streamAccount.feePercentage, feePercentage);
+    assert.isNotNull(streamAccount.streamBump);
+    assert.isNotNull(streamAccount.escrowBump);
+
+    // Check that the escrow PDA now holds the funds
+    const escrowTokenAccount = await getAccount(provider.connection, escrowPda);
+    assert.equal(
+      escrowTokenAccount.amount.toString(),
+      streamAmount.toString()
+    );
   });
 
-  it("Redeems a stream", async () => {
-    // Wait for at least 1 minute to ensure there are tokens available to redeem
-    console.log("Waiting for 65 seconds to ensure tokens are available for redemption...");
-    await new Promise(resolve => setTimeout(resolve, 65000));
+  it("Redeems from the stream as the payee", async () => {
+    // Wait for 1 minute to ensure there are tokens available to redeem
+    console.log(
+      "Waiting for 65 seconds to ensure tokens are available for redemption..."
+    );
+    await new Promise((resolve) => setTimeout(resolve, 65000));
 
+    // The `redeemStream` method no longer takes arguments
     await program.methods
-      .redeemStream(new anchor.BN(1))
+      .redeemStream()
       .accounts({
         stream: streamPda,
-        payer: payer,
+        escrowToken: escrowPda,
         payee: payee.publicKey,
+        payer: payer, // Payer pubkey is still needed for seed derivation
         payeeToken: payeeToken,
-        escrowToken: escrowToken,
         feeAccount: feeAccount,
         tokenProgram: TOKEN_PROGRAM_ID,
       })
-      .signers([payee])
+      .signers([payee]) // Only the payee needs to sign
       .rpc();
 
-    // Check payee token balance
+    // --- Verification ---
     const payeeTokenAccount = await getAccount(provider.connection, payeeToken);
-    console.log(`Payee received: ${payeeTokenAccount.amount.toString()} tokens`);
-    assert(Number(payeeTokenAccount.amount) > 0, "Payee should have received tokens");
-    
-    // Check stream account was updated
+    const feeTokenAccount = await getAccount(provider.connection, feeAccount);
     const streamAccount = await program.account.stream.fetch(streamPda);
-    assert(streamAccount.redeemed > 0, "Stream should have recorded redemption");
-  });
 
-  it("Reclaims a stream after expiration", async () => {
-    // Create a new stream with a very short duration
-    const shortStreamPayee = anchor.web3.Keypair.generate();
-    const shortStreamPayeeToken = await createAssociatedTokenAccount(
-      provider.connection,
-      provider.wallet.payer,
-      mint,
-      shortStreamPayee.publicKey
-    );
-    
-    // Create a new escrow token account for this stream
-    const shortStreamEscrowKeypair = Keypair.generate();
-    
-    // Create the token account
-    const tx = new anchor.web3.Transaction().add(
-      // Create account
-      SystemProgram.createAccount({
-        fromPubkey: payer,
-        newAccountPubkey: shortStreamEscrowKeypair.publicKey,
-        space: 165, // Size of token account
-        lamports: await provider.connection.getMinimumBalanceForRentExemption(165),
-        programId: TOKEN_PROGRAM_ID,
-      }),
-      // Initialize token account
-      createInitializeAccountInstruction(
-        shortStreamEscrowKeypair.publicKey,
-        mint,
-        payer
-      )
-    );
-    
-    await provider.sendAndConfirm(tx, [shortStreamEscrowKeypair]);
-    const shortStreamEscrowToken = shortStreamEscrowKeypair.publicKey;
-    
-    // Mint tokens to the payer's token account
-    await mintTo(
-      provider.connection,
-      provider.wallet.payer,
-      mint,
-      payerToken,
-      payer,
-      10 * LAMPORTS_PER_SOL
-    );
-    
-    // Find PDA for the new stream
-    const [shortStreamPda, shortStreamBump] = PublicKey.findProgramAddressSync(
-      [Buffer.from("stream"), payer.toBuffer(), shortStreamPayee.publicKey.toBuffer()],
-      program.programId
-    );
-    
-    // Transfer tokens to the escrow
-    await program.methods
-      .createStream(
-        new anchor.BN(5 * LAMPORTS_PER_SOL), 
-        new anchor.BN(5 * LAMPORTS_PER_SOL), // High rate to ensure full redemption
-        new anchor.BN(1), // 1 minute duration
-        5
-      )
-      .accounts({
-        stream: shortStreamPda,
-        payer: payer,
-        payee: shortStreamPayee.publicKey,
-        payerToken: payerToken,
-        escrowToken: shortStreamEscrowToken,
-        tokenProgram: TOKEN_PROGRAM_ID,
-        systemProgram: SystemProgram.programId,
-        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-      })
-      .rpc();
-    
-    // Wait for the stream to expire (a bit more than 1 minute)
-    console.log("Waiting for 65 seconds for stream to expire...");
-    await new Promise(resolve => setTimeout(resolve, 65000));
-    
-    // Reclaim the stream
-    await program.methods
-      .reclaimStream(new anchor.BN(1))
-      .accounts({
-        stream: shortStreamPda,
-        payer: payer,
-        payee: shortStreamPayee.publicKey,
-        escrowToken: shortStreamEscrowToken,
-        tokenProgram: TOKEN_PROGRAM_ID,
-      })
-      .rpc();
-    
-    // Check stream account was updated
-    const streamAccount = await program.account.stream.fetch(shortStreamPda);
+    // Expected amounts for 1 minute (rate is 1 SOL/min)
+    const expectedRedeemed = new anchor.BN(1 * LAMPORTS_PER_SOL);
+    const expectedFee = expectedRedeemed.muln(5).divn(100); // 5% fee
+    const expectedToPayee = expectedRedeemed.sub(expectedFee);
+
+    console.log(`Payee should receive: ${expectedToPayee}`);
+    console.log(`Fee account should receive: ${expectedFee}`);
+
     assert.equal(
-      streamAccount.redeemed.toString(), 
-      streamAccount.amount.toString(),
-      "Stream should be fully redeemed after reclaim"
+      payeeTokenAccount.amount.toString(),
+      expectedToPayee.toString(),
+      "Payee did not receive the correct amount"
+    );
+    assert.equal(
+      feeTokenAccount.amount.toString(),
+      expectedFee.toString(),
+      "Fee account did not receive the correct amount"
+    );
+    assert.equal(
+      streamAccount.redeemed.toString(),
+      expectedRedeemed.toString(),
+      "Stream redeemed amount was not updated correctly"
     );
   });
 });


### PR DESCRIPTION
## Changes

- Escrow authority PDA is now consistently used as the token account authority for all transfers and for closing the escrow account.
- Escrow authority bump is stored on the stream account for correct PDA derivation.
- Tests extended to verify channel closure and rent refund after stream cancellation.

## Why?

Previously, the escrow account was controlled by the payer, defeating the purpose of escrow and enabling the payer to bypass the streaming logic.